### PR TITLE
Add idea-based prompt mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ OR extend and bring your favorite models to the same experience.
 - **Hover animations** and professional transitions
 - **Real-time loading states** with skeleton animations
 - **Film strip navigation** to easily flip through your gneerations
+- **Idea mode** to build prompts from Subject, Scene and Vibe
 
 ## 🛠️ Tech Stack
 
@@ -80,6 +81,11 @@ Open [http://localhost:3000](http://localhost:3000) to view the app.
 2. Click **"Image"** button or press Enter
 3. Watch 4 high-quality images generate in real-time
 4. Hover to **Download**, **Expand**, or **Animate with Veo 2**
+
+### **Idea Mode**
+1. Switch to **Idea** above the prompt bar
+2. Fill in **Subject**, **Scene**, and **Vibe** or use **Shuffle**
+3. Click **"Visualize"** to generate an image from the composed prompt
 
 ### **Generating Videos**
 1. Type your video prompt

--- a/src/components/prompt-bar.tsx
+++ b/src/components/prompt-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ImageIcon, VideoIcon } from "lucide-react";
@@ -14,15 +15,50 @@ interface PromptBarProps {
 export function PromptBar({ onGenerate }: PromptBarProps) {
   const [prompt, setPrompt] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
+  const [mode, setMode] = useState<"text" | "idea">("text");
+  const [subject, setSubject] = useState("");
+  const [scene, setScene] = useState("");
+  const [vibe, setVibe] = useState("");
 
-  const handleGenerate = (type: "image" | "video") => {
-    if (!prompt.trim()) return;
+  const subjects = ["Wizard", "Robot", "Explorer", "Alien", "Pirate", "Dragon"];
+  const scenes = [
+    "futuristic city",
+    "enchanted forest",
+    "space station",
+    "underwater realm",
+    "desert landscape",
+    "cyberpunk alley",
+  ];
+  const vibes = [
+    "ethereal",
+    "dark",
+    "whimsical",
+    "serene",
+    "retro",
+    "vibrant",
+  ];
+
+  const ideaPrompt = `${subject}${subject && scene ? ` in ${scene}` : scene}${
+    (subject || scene) && vibe ? ", " : ""}${vibe}`.trim();
+
+  const randomFrom = (arr: string[]) =>
+    arr[Math.floor(Math.random() * arr.length)];
+
+  const handleShuffle = () => {
+    setSubject(randomFrom(subjects));
+    setScene(randomFrom(scenes));
+    setVibe(randomFrom(vibes));
+  };
+
+  const handleGenerate = (type: "image" | "video", customPrompt?: string) => {
+    const finalPrompt = (customPrompt ?? prompt).trim();
+    if (!finalPrompt) return;
     
     setIsGenerating(true);
     
     // Call the parent handler to add new generation
     if (onGenerate) {
-      onGenerate(type, prompt.trim());
+      onGenerate(type, finalPrompt);
     }
     
     // Clear the prompt
@@ -35,7 +71,7 @@ export function PromptBar({ onGenerate }: PromptBarProps) {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (mode === "text" && e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleGenerate("image"); // Default to image on Enter
     }
@@ -45,6 +81,24 @@ export function PromptBar({ onGenerate }: PromptBarProps) {
     <div className="w-full py-4">
       <div className="container mx-auto px-4">
         <div className="flex flex-col gap-4">
+          {/* Mode selector */}
+          <div className="flex gap-2 justify-center">
+            <Button
+              size="sm"
+              variant={mode === "text" ? "default" : "outline"}
+              onClick={() => setMode("text")}
+            >
+              Text
+            </Button>
+            <Button
+              size="sm"
+              variant={mode === "idea" ? "default" : "outline"}
+              onClick={() => setMode("idea")}
+            >
+              Idea
+            </Button>
+          </div>
+
           {/* Main prompt input */}
           <div className="flex flex-col sm:flex-row gap-4 items-center">
             {/* OpenJourney Logo */}
@@ -59,58 +113,141 @@ export function PromptBar({ onGenerate }: PromptBarProps) {
             </div>
             
             <div className="relative flex-1 w-full">
-              <Input
-                placeholder="Describe what you want to create..."
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                onKeyDown={handleKeyDown}
-                className="pr-2 sm:pr-44 h-12 text-base bg-card border-input"
-                disabled={isGenerating}
-              />
+              {mode === "text" ? (
+                <Input
+                  placeholder="Describe your clip..."
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="pr-2 sm:pr-44 h-12 text-base bg-card border-input"
+                  disabled={isGenerating}
+                />
+              ) : (
+                <Input
+                  placeholder="Compose your idea..."
+                  value={ideaPrompt}
+                  readOnly
+                  className="pr-2 sm:pr-44 h-12 text-base bg-card border-input"
+                />
+              )}
               <div className="absolute right-2 top-1/2 -translate-y-1/2 hidden sm:flex gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => handleGenerate("image")}
-                  disabled={!prompt.trim() || isGenerating}
-                  className="h-8"
-                >
-                  <ImageIcon className="w-4 h-4 mr-1" />
-                  Image
-                </Button>
-                <Button
-                  size="sm"
-                  onClick={() => handleGenerate("video")}
-                  disabled={!prompt.trim() || isGenerating}
-                  className="h-8"
-                >
-                  <VideoIcon className="w-4 h-4 mr-1" />
-                  Video
-                </Button>
+                {mode === "text" ? (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleGenerate("image")}
+                      disabled={!prompt.trim() || isGenerating}
+                      className="h-8"
+                    >
+                      <ImageIcon className="w-4 h-4 mr-1" />
+                      Image
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={() => handleGenerate("video")}
+                      disabled={!prompt.trim() || isGenerating}
+                      className="h-8"
+                    >
+                      <VideoIcon className="w-4 h-4 mr-1" />
+                      Video
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleShuffle}
+                      className="h-8"
+                    >
+                      Shuffle
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={() => handleGenerate("image", ideaPrompt)}
+                      className="h-8"
+                    >
+                      Visualize
+                    </Button>
+                  </>
+                )}
                 <SettingsDropdown />
               </div>
             </div>
           </div>
 
+          <AnimatePresence>
+            {mode === "idea" && (
+              <motion.div
+                key="idea-fields"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.3 }}
+                className="grid grid-cols-1 sm:grid-cols-3 gap-3 overflow-hidden"
+              >
+                <Input
+                  placeholder="Subject"
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  className="h-10"
+                />
+                <Input
+                  placeholder="Scene"
+                  value={scene}
+                  onChange={(e) => setScene(e.target.value)}
+                  className="h-10"
+                />
+                <Input
+                  placeholder="Vibe"
+                  value={vibe}
+                  onChange={(e) => setVibe(e.target.value)}
+                  className="h-10"
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+
           {/* Mobile buttons row */}
           <div className="flex sm:hidden gap-3 justify-center">
-            <Button
-              variant="outline"
-              onClick={() => handleGenerate("image")}
-              disabled={!prompt.trim() || isGenerating}
-              className="flex-1 h-10"
-            >
-              <ImageIcon className="w-4 h-4 mr-2" />
-              Image
-            </Button>
-            <Button
-              onClick={() => handleGenerate("video")}
-              disabled={!prompt.trim() || isGenerating}
-              className="flex-1 h-10"
-            >
-              <VideoIcon className="w-4 h-4 mr-2" />
-              Video
-            </Button>
+            {mode === "text" ? (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => handleGenerate("image")}
+                  disabled={!prompt.trim() || isGenerating}
+                  className="flex-1 h-10"
+                >
+                  <ImageIcon className="w-4 h-4 mr-2" />
+                  Image
+                </Button>
+                <Button
+                  onClick={() => handleGenerate("video")}
+                  disabled={!prompt.trim() || isGenerating}
+                  className="flex-1 h-10"
+                >
+                  <VideoIcon className="w-4 h-4 mr-2" />
+                  Video
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={handleShuffle}
+                  className="flex-1 h-10"
+                >
+                  Shuffle
+                </Button>
+                <Button
+                  onClick={() => handleGenerate("image", ideaPrompt)}
+                  className="flex-1 h-10"
+                >
+                  Visualize
+                </Button>
+              </>
+            )}
             <SettingsDropdown />
           </div>
 


### PR DESCRIPTION
## Summary
- add new Idea mode to prompt bar to build prompts via Subject, Scene and Vibe
- support tab selection for Text vs Idea and shuffle capability
- update readme with instructions for Idea mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a6970ed54832e8f9d8bff0b89acfe